### PR TITLE
Integration with perlbrew

### DIFF
--- a/Support/perlcheckmate.pl
+++ b/Support/perlcheckmate.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
+use Env qw($PERLBREW_PERL $PERLBREW_ROOT);
 
 # cwd should be $TM_DIRECTORY
 # filename to check is $ARGV[0]
@@ -30,8 +31,15 @@ sub read_source {
     $file_source{$file} = { source => \@file_source, path => $path };
 }
 
-my @lines = `perl -Tcw "$file" 2>&1`;
+my $perl;
 
+if ($PERLBREW_PERL) {
+	$perl = "$PERLBREW_ROOT/perls/$PERLBREW_PERL/bin/perl";
+} else {
+	$perl = 'perl';
+}
+
+my @lines = `"$perl" -Tcw "$file" 2>&1`;
 my $lines = join '', @lines;
 
 if ((scalar(@lines) == 1) && ($lines =~ m/ syntax OK$/s)) {


### PR DESCRIPTION
Hello,

I switch perl interpreters using perlbrew, sometimes my projects and installed perls are not aligned, so I get a lot of errors and warnings when executing perlcheckmate.pl

I have made a few minor changes by adding a few environment variables for detecting an active perlbrew and it's selected interpreter. Based on this a commandline is constructed which does not point to to the system perl solely and the active perlbrew is respected.

Let me know if you find it useful or if you want me to do some more work. For now it works for me.

jonasbn

My notes are collected here: https://logiclab.jira.com/wiki/display/OPEN/Textmate
