### PR TITLE
Change perl checker

### DIFF
--- a/Support/perlcheckmate.pl
+++ b/Support/perlcheckmate.pl
@@ -4,6 +4,7 @@ use strict;
 
 # cwd should be $TM_DIRECTORY
 # filename to check is $ARGV[0]
+chdir($ENV{TM_PROJECT_DIRECTORY});
 
 my $file = $ARGV[0];
 
@@ -30,7 +31,7 @@ sub read_source {
     $file_source{$file} = { source => \@file_source, path => $path };
 }
 
-my @lines = `perl -Tcw "$file" 2>&1`;
+my @lines = `perl -Ilib -cw "$file" 2>&1`;
 
 my $lines = join '', @lines;
 


### PR DESCRIPTION
This pull request disables taint checking, which is useless and doesn't work with many modules. It also runs from project root and includes 'lib', so that you can use it with modules that have dependencies on other classes in the same project.
