### PR TITLE
Propagate TextMate variable TM_PERL5LIB as PERL5LIB environment variable

### DIFF
--- a/Commands/Run Script (plain).plist
+++ b/Commands/Run Script (plain).plist
@@ -14,7 +14,10 @@ TextMate.save_if_untitled('pl')
 TextMate::Executor.make_project_master_current_document
 
 TextMate::Executor.run(ENV["TM_PERL"] || "perl", "-I#{ENV["TM_BUNDLE_SUPPORT"]}",
-     "-Mexception_handler", ENV["TM_FILEPATH"], :create_error_pipe =&gt; true, :version_args =&gt; ["-e", 'printf "Perl v%vd", $^V;'])
+     "-Mexception_handler", ENV["TM_FILEPATH"],
+     :env =&gt; {"PERL5LIB" =&gt; ENV["TM_PERL5LIB"]},
+     :create_error_pipe =&gt; true,
+     :version_args =&gt; ["-e", 'printf "Perl v%vd", $^V;'])
 </string>
 	<key>input</key>
 	<string>document</string>


### PR DESCRIPTION
If you have to customize PERL5LIB environment variable for perl development unter TextMate it is most comfortable to set it directly in TextMate. TM_PERL is already there, so it makes sense to introduce TM_PERL5LIB as a variable in TextMate.
