### PR TITLE
Run pod2html in /tmp/

### DIFF
--- a/Commands/View POD as HTML.plist
+++ b/Commands/View POD as HTML.plist
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>pod2html 2&gt;/dev/null &amp;&amp; rm -f pod2htmd.tmp pod2htmi.tmp</string>
+	<string>pod2html --cachedir=/tmp/ 2&gt;/dev/null &amp;&amp; rm -f /tmp/pod2htm*</string>
 	<key>input</key>
 	<string>document</string>
 	<key>keyEquivalent</key>


### PR DESCRIPTION
To allow tmp files to be created. If pod2html is installed in /opt/local/bin and the user running the command does not have write permission in that directory the "View POD as HTML" will fail.
