### PR TITLE
Add support for Perl-Critic

### DIFF
--- a/Commands/Check With Perl-Critic.tmCommand
+++ b/Commands/Check With Perl-Critic.tmCommand
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>saveActiveFile</string>
+	<key>command</key>
+	<string>#!/usr/bin/ruby
+
+# -- Imports -------------------------------------------------------------------
+
+require ENV['TM_BUNDLE_SUPPORT'] + '/perlcritic.rb'
+
+# -- Main ----------------------------------------------------------------------
+
+perl_critic</string>
+	<key>input</key>
+	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>keyEquivalent</key>
+	<string>~@c</string>
+	<key>name</key>
+	<string>Check With Perl-Critic</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
+	<key>requiredCommands</key>
+	<array>
+		<dict>
+			<key>command</key>
+			<string>perlcritic</string>
+			<key>locations</key>
+			<array>
+				<string>/usr/local/bin/perlcritic</string>
+			</array>
+			<key>variable</key>
+			<string>TM_PERLCRITIC</string>
+		</dict>
+	</array>
+	<key>scope</key>
+	<string>source.perl</string>
+	<key>uuid</key>
+	<string>3F862332-074A-447B-AF5B-00D54FAA50F7</string>
+	<key>version</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/Support/perlcritic.rb
+++ b/Support/perlcritic.rb
@@ -1,0 +1,53 @@
+# rubocop:disable Style/AsciiComments, Style/HashSyntax
+
+# Analyze the current file with Perl-Critic.
+#
+# Authors:: Guillaume Carbonneau
+#           Matt Foster
+#           René Schwaiger (sanssecours@f-m.fm)
+
+# -- Imports -------------------------------------------------------------------
+
+require ENV['TM_SUPPORT_PATH'] + '/lib/escape'
+require ENV['TM_SUPPORT_PATH'] + '/lib/tm/executor'
+
+# -- Functions -----------------------------------------------------------------
+
+# Format a single line of output from +perlcritic+.
+#
+# = Arguments
+#
+# [line] A single line of output produced by +perlcritic+
+# [show_reference] A boolean value that specifies if the output should include
+#                  references to the matching section of the book “Perl Best
+#                  Practices” (PBP).
+#
+# = Output
+#
+# The function returns a string containing HTML code.
+def format_critic_output(line, show_reference)
+  return 'No problems found — Yay!' if line.chomp.end_with?('source OK')
+  styles = { 5 => 'Red', 4 => 'GoldenRod', 3 => 'DodgerBlue' }
+  styles.default = ''
+  file, line_number, column, message, reference, severity = line.split(':')
+  link = "txmt://open?url=file://#{e_url file}&amp;line=#{line_number}" \
+         "&amp;column=#{column}"
+  "<span class='out' style='color:#{styles[severity.to_i]};'>
+      (Severity: #{severity.to_i})</span> #{message}
+   <a href='#{link}'>at line #{line_number}, column #{column}</a>.
+   #{reference + '.' if show_reference}<br />"
+end
+
+# Output an HMTL formatted analysis of the current Perl file by +perlcritic+.
+def perl_critic
+  show_reference = ENV['TM_PERLCRITIC_REFERENCE'] ? true : false
+  TextMate::Executor.run(
+    ENV['TM_PERLCRITIC'] || 'perlcritic', '--verbose', '%f:%l:%c:%m:%e:%s\n',
+    ENV['TM_PERLCRITIC_LEVEL'] || '--stern', '--nocolor', ENV['TM_FILEPATH'],
+    :use_hashbang => false, :verb => 'Criticizing') do |line, type|
+    case type
+    when :err then "<span class='err'>#{htmlize(line)}</span>"
+    when :out then format_critic_output(line, show_reference)
+    end
+  end
+end

--- a/info.plist
+++ b/info.plist
@@ -19,6 +19,7 @@
 			<string>------------------------------------</string>
 			<string>DA0A5FEC-5F16-11D9-B9C3-000D93589AF6</string>
 			<string>DA0A5F4B-5F16-11D9-B9C3-000D93589AF6</string>
+			<string>3F862332-074A-447B-AF5B-00D54FAA50F7</string>
 			<string>CF2CA4F9-82A7-11D9-8753-000D9332809C</string>
 			<string>DA0A5E1E-5F16-11D9-B9C3-000D93589AF6</string>
 			<string>------------------------------------</string>


### PR DESCRIPTION
Hi,

this commit adds support for [Perl-Critic](https://github.com/Perl-Critic/Perl-Critic). The code for the command is based on work by [Guillaume Carbonneau](http://textmate.1073791.n5.nabble.com/Perl-textmate-bundle-enhancement-Perlcritic-td23486.html) and [Matt Foster](http://lists.macromates.com/textmate-dev/2009-February/013629.html). I added them both as authors in `perlcritic.rb`.

Here is an example screenshot of the command at work:

![perl-critic](https://cloud.githubusercontent.com/assets/691989/6885342/7b126246-d61c-11e4-9330-39d9863ead88.png)

Kind regards,
  René
