### PR TITLE
wrong coloring when space after regexp

### DIFF
--- a/Syntaxes/Perl.plist
+++ b/Syntaxes/Perl.plist
@@ -56,7 +56,7 @@
 			<key>comment</key>
 			<string>string.regexp.compile.perl</string>
 			<key>end</key>
-			<string>((([egimosxradlupc]*)))(?=(\s+\S|\s*[;\,\#\{\}\)]|$))</string>
+			<string>((([egimosxradlupc]*)))(?=(\s+\S|\s*[;\,\#\{\}\)]|\s*$))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -309,7 +309,7 @@
 			<key>comment</key>
 			<string>string.regexp.find-m.perl</string>
 			<key>end</key>
-			<string>((([egimosxradlupc]*)))(?=(\s+\S|\s*[;\,\#\{\}\)]|$))</string>
+			<string>((([egimosxradlupc]*)))(?=(\s+\S|\s*[;\,\#\{\}\)]|\s*$))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -595,7 +595,7 @@
 			<key>comment</key>
 			<string>string.regexp.replace.perl</string>
 			<key>end</key>
-			<string>((([egimosxradlupc]*)))(?=(\s+\S|\s*[;\,\#\{\}\)\]&gt;]|$))</string>
+			<string>((([egimosxradlupc]*)))(?=(\s+\S|\s*[;\,\#\{\}\)\]&gt;]|\s*$))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -932,7 +932,7 @@
 			<key>comment</key>
 			<string>string.regexp.replaceXXX</string>
 			<key>end</key>
-			<string>((([egimosxradlupc]*)))(?=([\}\)\;\,]|\s+|$))</string>
+			<string>((([egimosxradlupc]*)))(?=([\}\)\;\,]|\s+|\s*$))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -1161,7 +1161,7 @@
 			<key>contentName</key>
 			<string>string.regexp.find.perl</string>
 			<key>end</key>
-			<string>((\1([egimosxradlupc]*)))(?=(\s+\S|\s*[;\,\#\{\}\)]|$))</string>
+			<string>((\1([egimosxradlupc]*)))(?=(\s+\S|\s*[;\,\#\{\}\)]|\s*$))</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
From issue reported as https://github.com/Microsoft/vscode/issues/6591:

This perl code is colored with mistake:
Note the space after the last regexp ( `/Home_Bind_Count/i` ).
![image](https://cloud.githubusercontent.com/assets/12115586/15440130/9dec5c6c-1e88-11e6-803c-56111d727d6b.png)

```
die("[$sheet->{label}] Unexpected sheet format.") unless (
        $sheet->{"$date_col$row"} =~ /CALL_DATE/i &&
        $sheet->{"$phone_col$row"} =~ /ANI_VAL/i  &&
        $sheet->{"$pixel_cols[1]$row"} =~ /Auto_Quote_Count/i &&
        $sheet->{"$pixel_cols[2]$row"} =~ /Auto_Bind_Count/i &&
        $sheet->{"$pixel_cols[3]$row"} =~ /Home_Quote_Count/i &&
        $sheet->{"$pixel_cols[4]$row"} =~ /Home_Bind_Count/i 
    );

    $row++;
    while ($row < $sheet->{maxrow}) {
        $row++;
        $total_lines++;

        my $date = $sheet->{"$date_col$row"};
        next unless $date;
        (warning "Unexpected date format: '$date'"), next unless ($date =~ /^2\d\d\d-\d\d-\d\d$/);

        my $phone = trim($sheet->{"$phone_col$row"});
        (warning "Unexpected phone format: '$phone'."), next unless ($phone =~ /^\d{10}$/);

        info $phone;
        next if ($date gt $date_to || $date lt $date_from);

        my @pixels = (0) x 5;
        for (1..4) {
            $pixels[$_] = trim($sheet->{"$pixel_cols[4]$row"});
            (warning "Pixel $_ is not a number in the row # $row."), next unless looks_like_number($pixels[$_]);
        };

        for (1..4) {
            add_phone_activity($date, $phone, "pixel-$_", $pixels[$_]) if $pixels[$_];
        };
        $parsed_lines++;
    };
```
