### PR TITLE
Fix Perl POD comment syntax highlighting

### DIFF
--- a/Syntaxes/Perl.plist
+++ b/Syntaxes/Perl.plist
@@ -30,7 +30,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^=</string>
+			<string>^=[a-zA-Z]+</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
- because there is a false positive when using spaceship
  operator at the beginning of line
- this is inspired by http://perldoc.perl.org/perlpodspec.html
