### PR TITLE
allow SQL heredoc markers to be indented

### DIFF
--- a/Syntaxes/Perl.plist
+++ b/Syntaxes/Perl.plist
@@ -1634,7 +1634,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(((&lt;&lt;) *"SQL"))(.*)\n?</string>
+			<string>((&lt;&lt;) *"(\s*SQL)")(.*)\n?</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -1645,12 +1645,12 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>string.unquoted.heredoc.doublequote.perl</string>
+					<string>punctuation.definition.heredoc.perl</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.heredoc.perl</string>
+					<string>string.unquoted.heredoc.doublequote.perl</string>
 				</dict>
 				<key>4</key>
 				<dict>
@@ -1666,7 +1666,7 @@
 			<key>contentName</key>
 			<string>source.sql.embedded.perl</string>
 			<key>end</key>
-			<string>(^SQL$)</string>
+			<string>(^\3$)</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -1955,7 +1955,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(((&lt;&lt;) *'SQL'))(.*)\n?</string>
+			<string>((&lt;&lt;) *'(\s*)SQL')(.*)\n?</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -1966,12 +1966,12 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>string.unquoted.heredoc.quote.perl</string>
+					<string>punctuation.definition.heredoc.perl</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.heredoc.perl</string>
+					<string>string.unquoted.heredoc.quote.perl</string>
 				</dict>
 				<key>4</key>
 				<dict>
@@ -1987,7 +1987,7 @@
 			<key>contentName</key>
 			<string>source.sql.embedded.perl</string>
 			<key>end</key>
-			<string>(^SQL$)</string>
+			<string>(^\3$)</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
Perl allows the heredoc markers to start with whitespace. This can be used to have the end marker be indented. For SQL I changed the rules so that this works. I'm not sure whether or not I did it right as I'm only using vscodium where I only have a JSON file created from the TextMate files. Poking around in my vscodium json file to implement this change worked.