### PR TITLE
Add support dereferencing with block

### DIFF
--- a/Syntaxes/Perl.plist
+++ b/Syntaxes/Perl.plist
@@ -2195,8 +2195,6 @@
 			<string>(\()(\))</string>
 		</dict>
 		<dict>
-			<key>comment</key>
-			<string>Match a code block</string>
 			<key>begin</key>
 			<string>\{</string>
 			<key>beginCaptures</key>
@@ -2207,6 +2205,8 @@
 					<string>punctuation.section.scope.begin.js</string>
 				</dict>
 			</dict>
+			<key>comment</key>
+			<string>Match a code block or a hash data.</string>
 			<key>end</key>
 			<string>\}</string>
 			<key>endCaptures</key>

--- a/Syntaxes/Perl.plist
+++ b/Syntaxes/Perl.plist
@@ -4619,10 +4619,15 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>[\$\@\%\&amp;]\{</string>
+					<string>([\$\@\%\&amp;]\{)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.global.special.perl</string>
+						</dict>
+						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.variable.perl</string>
@@ -4631,17 +4636,20 @@
 					<key>contentName</key>
 					<string>meta.embedded.block.perl</string>
 					<key>end</key>
-					<string>\}</string>
+					<string>(\})</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>0</key>
 						<dict>
 							<key>name</key>
+							<string>variable.other.readwrite.global.special.perl</string>
+						</dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
 							<string>punctuation.definition.variable.perl</string>
 						</dict>
 					</dict>
-					<key>name</key>
-					<string>variable.other.readwrite.global.perl</string>
 					<key>patterns</key>
 					<array>
 						<dict>

--- a/Syntaxes/Perl.plist
+++ b/Syntaxes/Perl.plist
@@ -4617,6 +4617,39 @@
 					<key>name</key>
 					<string>variable.other.readwrite.global.special.perl</string>
 				</dict>
+				<dict>
+					<key>begin</key>
+					<string>[\$\@\%\&amp;]\{</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.variable.perl</string>
+						</dict>
+					</dict>
+					<key>contentName</key>
+					<string>meta.embedded.block.perl</string>
+					<key>end</key>
+					<string>\}</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.variable.perl</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>variable.other.readwrite.global.perl</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+					</array>
+				</dict>
 			</array>
 		</dict>
 	</dict>

--- a/Syntaxes/Perl.plist
+++ b/Syntaxes/Perl.plist
@@ -2190,28 +2190,40 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Match empty brackets for ↩ snippet</string>
-			<key>match</key>
-			<string>(\{)(\})</string>
-		</dict>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.scope.begin.perl</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.scope.end.perl</string>
-				</dict>
-			</dict>
-			<key>comment</key>
 			<string>Match empty parenthesis for ↩ snippet</string>
 			<key>match</key>
 			<string>(\()(\))</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Match a code block</string>
+			<key>begin</key>
+			<string>\{</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.scope.begin.js</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\}</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.scope.end.js</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+			</array>
 		</dict>
 	</array>
 	<key>repository</key>


### PR DESCRIPTION
Hi,

This pull request contains adding support dereferencing with block.
https://metacpan.org/pod/perlref#Block

We can use the following syntax to dereference.

```perl
print ${\"string"};
print @{[lc("STRING")]};
print %{{1 => 2}};
print &{sub{ "sub" }};
```

This syntax is often used to embed expressions in strings.
https://github.com/leejo/CGI.pm/blob/master/lib/CGI.pm#L3638


19974bcf1a6054a22628084698e0a43dead901bd makes match a code block, for example, as in the following JavaScript plist.
https://github.com/textmate/javascript.tmbundle/blob/master/Syntaxes/JavaScript.plist#L1047-L1075

Then, 5e87c64368ac765383a6b7ca2ec8497ed0a1edac handles dereferencing.


And the following syntax is a pattern of dereferencing with block, so I think we can also add the following changes.

```perl
${$variable};
```

```diff
diff --git a/Syntaxes/Perl.plist b/Syntaxes/Perl.plist
index cfc22d9..4ac01e8 100644
--- a/Syntaxes/Perl.plist
+++ b/Syntaxes/Perl.plist
@@ -4587,7 +4587,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\$\{)(?:[a-zA-Zx7f-xff\$]|::)(?:[a-zA-Z0-9_x7f-xff\$]|::)*(\})</string>
+					<string>(\$\{)(?:[a-zA-Zx7f-xff]|::)(?:[a-zA-Z0-9_x7f-xff]|::)*(\})</string>
 					<key>name</key>
 					<string>variable.other.readwrite.global.perl</string>
 				</dict>
```



Kind regards,
