### PR TITLE
Detect Raku

### DIFF
--- a/Syntaxes/Perl 6.tmLanguage
+++ b/Syntaxes/Perl 6.tmLanguage
@@ -8,6 +8,8 @@
 		<string>pl6</string>
 		<string>pm6</string>
 		<string>nqp</string>
+		<string>raku</string>
+		<string>rakumod</string>
 	</array>
 	<key>firstLineMatch</key>
 	<string>(?x)

--- a/Syntaxes/Perl 6.tmLanguage
+++ b/Syntaxes/Perl 6.tmLanguage
@@ -14,7 +14,7 @@
 	<key>firstLineMatch</key>
 	<string>(?x)
 # Hashbang
-^\#!.*(?:\s|\/|(?&lt;=!)\b)(?:perl6|nqp)(?:$|\s)
+^\#!.*(?:\s|\/|(?&lt;=!)\b)(?:perl6|nqp|raku)(?:$|\s)
 |
 # Perl 6 pragma
 \buse\s+v6\b


### PR DESCRIPTION
When Perl 6 was renamed Raku a few years back, it got new file extensions and a new compiler/interpreter name.  This attempts to add support for `.raku` and `.rakumod`, as well as a `raku` hashbang.  Unfortunately I don't know how to test a Bundle in this form, but the changes seemed extremely straightforward, so I'm hoping they work.